### PR TITLE
chore: remove cmake deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,11 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(ros_gazebo_gym)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
 # add_compile_options(-std=c++11)
 
 ## Find catkin macros and libraries
+# NOTE: Finds dependencies for this package. Needed for building
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
@@ -15,7 +16,6 @@ find_package(catkin REQUIRED COMPONENTS
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
-
 
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
@@ -48,9 +48,9 @@ catkin_python_setup()
 
 ## Generate messages in the 'msg' folder
 add_message_files(
-   FILES
-   RLExperimentInfo.msg
- )
+  FILES
+  RLExperimentInfo.msg
+)
 
 ## Generate services in the 'srv' folder
 # add_service_files(
@@ -68,9 +68,9 @@ add_message_files(
 
 ## Generate added messages and services with any dependencies listed here
 generate_messages(
-   DEPENDENCIES
-   std_msgs
- )
+  DEPENDENCIES
+  std_msgs
+)
 
 ################################################
 ## Declare ROS dynamic reconfigure parameters ##
@@ -95,6 +95,7 @@ generate_messages(
 ###################################
 ## catkin specific configuration ##
 ###################################
+# NOTE: Declares dependencies for packages that depend on this package.
 ## The catkin_package macro generates cmake config files for your package
 ## Declare things to be passed to dependent projects
 ## INCLUDE_DIRS: uncomment this if your package contains header files
@@ -102,9 +103,12 @@ generate_messages(
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-  CATKIN_DEPENDS rospy gazebo_msgs std_msgs geometry_msgs controller_manager_msgs message_runtime
+#  INCLUDE_DIRS include
+#  LIBRARIES beginner_tutorials
+  CATKIN_DEPENDS 
+    rospy gazebo_msgs std_msgs geometry_msgs controller_manager_msgs message_runtime
     rospy_message_converter actionlib_msgs jsk_rviz_plugins tf2_geometry_msgs sensor_msgs
-  # system_lib
+#  DEPENDS system_lib
 )
 
 ###########
@@ -157,7 +161,7 @@ include_directories(
 
 ## Mark executable scripts (Python etc.) for installation
 ## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
+# catkin_install_python(PROGRAMS
 #   scripts/my_python_script
 #   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 # )


### PR DESCRIPTION
This commit removes the cmake min version < 3.5 deprecation warning.
