### PR TITLE
refactor: add rosdep rules folder and documentation

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -93,6 +93,8 @@
   <!-- <exec_depend>robotx_gazebo</exec_depend> -->
 
   <!-- Python dependencies -->
+  <exec_depend>python-gymnasium-pip</exec_depend>
+  <exec_depend>python-gymnasium-robotics-pip</exec_depend>
   <exec_depend>python3-numpy</exec_depend>
   <exec_depend>python3-pygit2</exec_depend>
   <exec_depend>python3-ruamel.yaml</exec_depend>

--- a/rosdep/19-ros-gazebo-gym.list
+++ b/rosdep/19-ros-gazebo-gym.list
@@ -1,0 +1,4 @@
+# Adds custom rosdep rules to the rosdep database.
+# NOTE: Done because gymnasium and gymnasium-robotics require numpy>=1.20.1 while 
+# python==1.17.4 is installed on Ubuntu 20.04 by default.
+yaml https://github.com/rickstaa/ros-gazebo-gym/rosdep/rosdep.yaml

--- a/rosdep/README.md
+++ b/rosdep/README.md
@@ -1,0 +1,22 @@
+# Custom ros-gazebo-gym rosdep rules
+
+This folder contains custom [rosdep](https://wiki.ros.org/rosdep) rules for the `ros-gazebo-gym` package. These rules were created to resolve conflicting requirements between the `python3-gymnasium-pip` and `python3-gymnasium-robotics` rules and the `python3-numpy` rule on [Ubuntu 20.04](https://releases.ubuntu.com/focal/). Specifically, `gymnasium` requires `numpy>=1.20.1`, but the `python3-numpy` rule installs `numpy==1.17.4` (see https://github.com/ros/rosdistro/issues/38332).
+
+> \[!IMPORTANT]\
+> While the steps provided here will work, it is recommended that you use a virtual environment to keep your ROS system packages separate from your project-specific packages. This can help avoid conflicts and ensure reproducibility. To create a virtual environment, you can use the venv package and install the correct Numpy, gymnasium and gymnasium-robotics versions directly using pip. When creating the virtual environment, make sure to include the `--system-site-packages` flag so that the ROS system packages are available in the virtual environment.
+
+## Usage
+
+To use these rules, follow these steps:
+
+1.  Copy or download the `19-ros-gazebo-gym.list` file to the `/etc/ros/rosdep/sources.list.d/` folder.
+2.  Run `rosdep update` to update the Rosdep database.
+3.  Run `rosdep install --reinstall ros-gazebo-gym` to install the dependencies of the `ros-gazebo-gym` package. Note that the `--reinstall` flag is necessary because `python3-numpy` is already installed when ROS is installed.
+
+## Restoring Default Rules
+
+If you want to restore the default rules, follow these steps:
+
+1.  Remove the `19-ros-gazebo-gym.list` file from the `/etc/ros/rosdep/sources.list.d/` folder.
+2.  Run `rosdep update` to update the Rosdep database.
+3.  Run `rosdep install --reinstall ros-gazebo-gym` to install the dependencies of the `ros-gazebo-gym` package. Note that the `--reinstall` flag is necessary because `python3-numpy` is already installed when ROS is installed.

--- a/rosdep/rosdep.yaml
+++ b/rosdep/rosdep.yaml
@@ -1,0 +1,15 @@
+# Custom dependency overwrites for rosdep.
+python3-gymnasium-pip:
+  ubuntu:
+    focal: 
+      pip:
+        packages: [gymnasium]
+python3-gymnasium-robotics-pip:
+  ubuntu:
+    focal: 
+      pip:
+        packages: [gymnasium-robotics]
+python3-numpy:
+  ubuntu:
+      pip:
+        packages: [numpy]


### PR DESCRIPTION
This pull request adds a custom [rosdep](https://wiki.ros.org/rosdep) rules folder and documentation. This was done to resolve
conflicting requirements between the `python3-gymnasium-pip` and `python3-gymnasium-robotics` rules and the `python3-numpy` rule on [Ubuntu 20.04](https://releases.ubuntu.com/focal/). Specifically, `gymnasium` requires `numpy>=1.20.1`, but the `python3-numpy` rule installs `numpy==1.17.4` (see https://github.com/ros/rosdistro/issues/38332).

> [!important]\
> Should be merged after https://github.com/ros/rosdistro/pull/38341, https://github.com/ros/rosdistro/pull/38244 and .