### PR TITLE
fix: fix action space dtype

### DIFF
--- a/src/ros_gazebo_gym/robot_gazebo_env.py
+++ b/src/ros_gazebo_gym/robot_gazebo_env.py
@@ -339,6 +339,9 @@ class RobotGazeboEnv(gym.Env):
         Args:
             observations (numpy.ndarray): The observations.
 
+        Returns:
+            bool: Whether the episode was finished.
+
         Raises:
             NotImplementedError: Thrown When the method was not overloaded by the task
                 environment.
@@ -350,7 +353,7 @@ class RobotGazeboEnv(gym.Env):
 
         Args:
             observations (numpy.ndarray): The observations.
-            done (function): Whether the episode was done.
+            done (bool): Whether the episode was done.
 
         Raises:
             NotImplementedError: Thrown When the method was not overloaded by the task

--- a/src/ros_gazebo_gym/robot_gazebo_goal_env.py
+++ b/src/ros_gazebo_gym/robot_gazebo_goal_env.py
@@ -350,6 +350,9 @@ class RobotGazeboGoalEnv(gymrobot.GoalEnv):
         Args:
             observations (numpy.ndarray): The observations.
 
+        Returns:
+            bool: Whether the episode was finished.
+
         Raises:
             NotImplementedError: Thrown When the method was not overloaded by the task
                 environment.

--- a/src/ros_gazebo_gym/task_envs/panda/panda_pick_and_place.py
+++ b/src/ros_gazebo_gym/task_envs/panda/panda_pick_and_place.py
@@ -487,12 +487,15 @@ class PandaPickAndPlaceEnv(PandaReachEnv, utils.EzPickle):
                 object_velp.ravel(),
                 object_velr.ravel(),
                 ee_vel,
-            ]
+            ],
+            dtype=self._observation_space_dtype,
         )
+        achieved_goal = np.array(ee_position, dtype=self._observation_space_dtype)
+        desired_goal = self.goal.astype(self._observation_space_dtype)
 
         return {
-            "observation": obs.copy(),
-            "achieved_goal": achieved_goal.copy(),
+            "observation": obs,
+            "achieved_goal": achieved_goal,
             "desired_goal": desired_goal,
         }
 


### PR DESCRIPTION
This pull request ensures that the action dtype is correctly converted and a warning is thrown when the user supplies the wrong dtype. It also fixes the dtype of the terminated boolean that is returned by the step method.
