### PR TITLE
ci: fix documentation ci

### DIFF
--- a/.ci/Dockerfile.noetic
+++ b/.ci/Dockerfile.noetic
@@ -14,4 +14,5 @@ RUN apt-get update && apt-get install -y \
     python3-pygit2 \
     python3-ruamel.yaml \
     python3-tqdm \
+    ros-noetic-rosdoc-lite \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This pull request ensures that the documentation CI has rosdoc_lite available
when running.
