### PR TITLE
ci: fix documentation build action

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -54,12 +54,12 @@ jobs:
           run: |
             . /devel/setup.bash
             pip install -r ../src/requirements/doc_requirements.txt
-            rosdoc_lite ../src/ros_gazebo_gym -o ../src/ros_gazebo_gym/docs/build
+            rosdoc_lite ../src -o ../src/docs/build
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: src/ros_gazebo_gym/docs/build/html
+          publish_dir: src/docs/build/html
           force_orphan: true


### PR DESCRIPTION
This commit ensures that `rosdoc_lite` receives the right folders when
trying to build the documentation.
