### PR TITLE
fix: ensure control is compatible with panda_gazebo v2.16.1

### DIFF
--- a/src/ros_gazebo_gym/common/helpers.py
+++ b/src/ros_gazebo_gym/common/helpers.py
@@ -4,6 +4,8 @@ import copy
 import glob
 import os
 import re
+import sys
+from contextlib import contextmanager
 
 import numpy as np
 import rospy
@@ -389,6 +391,19 @@ def deep_update(d, u=None, fixed=False, **kwargs):  # noqa: C901
     return d
 
 
+def is_sublist(lst1, lst2):
+    """Checks whether lst1 is a sublist of lst2.
+
+    Args:
+        lst1 (list): List 1.
+        lst2 (list): List 2.
+
+    Returns:
+        bool: Boolean specifying whether lst1 is a sublist of lst2.
+    """
+    return all(element in lst2 for element in lst1)
+
+
 #################################################
 # Argument validation functions #################
 #################################################
@@ -622,3 +637,30 @@ def normalize_quaternion(quaternion):
         quaternion.w = quaternion.w / norm
 
     return quaternion
+
+
+class DummyFile(object):
+    """Dummy file class to redirect stderr to."""
+
+    def write(self, x):
+        """Writes the given string to the dummy file."""
+        pass
+
+
+@contextmanager
+def suppress_stderr():
+    """Suppresses the stderr output of a code block.
+
+    Example:
+            .. code-block:: python
+
+                with suppress_stderr():
+                    # Code block that will not print stderr.
+                    sys.stderr.write("This will not be printed.")
+    """
+    orig_stderr = sys.stderr
+    sys.stderr = DummyFile()
+    try:
+        yield
+    finally:
+        sys.stderr = orig_stderr

--- a/src/ros_gazebo_gym/robot_envs/helpers.py
+++ b/src/ros_gazebo_gym/robot_envs/helpers.py
@@ -1,0 +1,18 @@
+"""Contains several helper functions that are used in the robot environments."""
+
+
+def remove_gripper_commands_from_joint_commands_msg(joint_commands_msg):
+    """Removes the gripper commands from the joint commands message.
+
+    Args:
+        joint_commands_msg (:obj:`panda_gazebo.msg.JointCommands`): The joint
+            commands message.
+    """
+    joint_commands = dict(
+        zip(joint_commands_msg.joint_names, joint_commands_msg.joint_commands)
+    )
+    joint_commands.pop("gripper_width", None)
+    joint_commands.pop("gripper_max_effort", None)
+    joint_commands_msg.joint_names = list(joint_commands.keys())
+    joint_commands_msg.joint_commands = list(joint_commands.values())
+    return joint_commands_msg


### PR DESCRIPTION
This pull request ensures the position and gripper control is compatible with the changes made in [panda_gazebo v2.16.1](https://github.com/rickstaa/panda-gazebo/releases/tag/v2.16.1).

Additionally, it also ensures that:
- Gripper commands are only sent when different from the
previous command.
- Adds additional environment input arguments validation logic.
- Cleans up the codebase a bit.
