### PR TITLE
fix: temporary remove ee_frame_offset parameter

### DIFF
--- a/src/ros_gazebo_gym/task_envs/panda/config/panda_reach.yaml
+++ b/src/ros_gazebo_gym/task_envs/panda/config/panda_reach.yaml
@@ -142,19 +142,6 @@ panda_reach:
     distance_threshold: 0.05 # The threshold for determining a target has been reached.
     collision_penalty: 0.0 # The penalty given for when the robot is in collision. Set to `0.0` if you don't want to use a collision penalty.
 
-    # Reward frame offset (Only used in REACH environment)
-    # NOTE: Normally, the distance between the `ee_frame` and the `target` is used to
-    # calculate the reward. If you want to change this but have no TF frame available,
-    # you can use the offset below.
-    ee_frame_offset:
-      x: 0.0
-      y: 0.0
-      z: 0.0
-      rx: 0.0
-      ry: 0.0
-      rz: 0.0
-      rw: 1.0
-
   ########################################
   # Environment settings #################
   ########################################

--- a/src/ros_gazebo_gym/task_envs/panda/panda_reach.py
+++ b/src/ros_gazebo_gym/task_envs/panda/panda_reach.py
@@ -317,7 +317,6 @@ class PandaReachEnv(PandaEnv, utils.EzPickle):
         # Initialize the Robot environment.
         super(PandaReachEnv, self).__init__(
             robot_EE_link=self._ee_link,
-            ee_frame_offset=self._ee_frame_offset,
             load_gripper=self._load_gripper,
             block_gripper=self._block_gripper,
             control_type=control_type,
@@ -659,12 +658,6 @@ class PandaReachEnv(PandaEnv, utils.EzPickle):
                 )
             except KeyError:
                 self._controlled_joints = None
-            try:
-                self._ee_frame_offset = rospy.get_param(
-                    f"/{ns}/control/ee_frame_offset"
-                )
-            except KeyError:
-                self._ee_frame_offset = None
             # Retrieve sampling variables.
             try:
                 self._visualize_init_pose_bounds = rospy.get_param(


### PR DESCRIPTION
This pull request temporarily removes the broken `ee_frame_offset` parameter. This parameter was broken due to #70. In a future commit, we will add this parameter back in the correct form.
