### PR TITLE
fix: fix max vel/acc scaling undefined error

### DIFF
--- a/src/ros_gazebo_gym/robot_envs/panda_env.py
+++ b/src/ros_gazebo_gym/robot_envs/panda_env.py
@@ -286,8 +286,12 @@ class PandaEnv(RobotGazeboGoalEnv):
             disable_franka_gazebo_logs=True,
             rviz_file=self._rviz_file if hasattr(self, "_rviz_file") else "",
             end_effector=self.robot_EE_link,
-            max_velocity_scaling_factor=self._max_velocity_scaling_factor,
-            max_acceleration_scaling_factor=self._max_acceleration_scaling_factor,
+            max_velocity_scaling_factor=self._max_velocity_scaling_factor
+            if hasattr(self, "_max_velocity_scaling_factor")
+            else "",
+            max_acceleration_scaling_factor=self._max_acceleration_scaling_factor
+            if hasattr(self, "_max_acceleration_scaling_factor")
+            else "",
             control_type=control_type_group,
         )
 


### PR DESCRIPTION
This pull request ensures no error is thrown when the parent task environment does not set the `self._max_velocity_scaling_factor` and `self._max_acceleration_scaling_factor` attributes.
