### PR TITLE
refactor: change 'pause_after_step' default to True

### DIFF
--- a/src/ros_gazebo_gym/task_envs/panda/config/panda_pick_and_place.yaml
+++ b/src/ros_gazebo_gym/task_envs/panda/config/panda_pick_and_place.yaml
@@ -174,7 +174,7 @@ panda_pick_and_place:
   # Environment settings #################
   ########################################
   environment:
-    pause_after_step: False # Pause the simulation after each step.
+    pause_after_step: True # Pause the simulation after each step.
     # The environment action space
     action_space:
       bounds:

--- a/src/ros_gazebo_gym/task_envs/panda/config/panda_push.yaml
+++ b/src/ros_gazebo_gym/task_envs/panda/config/panda_push.yaml
@@ -173,7 +173,7 @@ panda_push:
   # Environment settings #################
   ########################################
   environment:
-    pause_after_step: False # Pause the simulation after each step.
+    pause_after_step: True # Pause the simulation after each step.
     # The environment action space
     action_space:
       bounds:

--- a/src/ros_gazebo_gym/task_envs/panda/config/panda_reach.yaml
+++ b/src/ros_gazebo_gym/task_envs/panda/config/panda_reach.yaml
@@ -153,7 +153,7 @@ panda_reach:
   # Environment settings #################
   ########################################
   environment:
-    pause_after_step: False # Pause the simulation after each step.
+    pause_after_step: True # Pause the simulation after each step.
     # The environment action space
     action_space:
       bounds:

--- a/src/ros_gazebo_gym/task_envs/panda/config/panda_slide.yaml
+++ b/src/ros_gazebo_gym/task_envs/panda/config/panda_slide.yaml
@@ -173,7 +173,7 @@ panda_slide:
   # Environment settings #################
   ########################################
   environment:
-    pause_after_step: False # Pause the simulation after each step.
+    pause_after_step: True # Pause the simulation after each step.
     # The environment action space
     action_space:
       bounds:

--- a/src/ros_gazebo_gym/task_envs/panda/panda_reach.py
+++ b/src/ros_gazebo_gym/task_envs/panda/panda_reach.py
@@ -839,7 +839,7 @@ class PandaReachEnv(PandaEnv, utils.EzPickle):
                     f"/{ns}/environment/pause_after_step"
                 )
             except KeyError:
-                self._pause_after_step = False
+                self._pause_after_step = True
             try:
                 self._action_bounds = rospy.get_param(
                     f"/{ns}/environment/action_space/bounds"


### PR DESCRIPTION
This commit changes the `pause_after_step` setting to `True` as the default. This was done since this is commonly done when not having to use the trained model on a real system.
